### PR TITLE
fixed gnustl map/set having incorrect size

### DIFF
--- a/broma_ida/types/stl_types.hpp
+++ b/broma_ida/types/stl_types.hpp
@@ -13,6 +13,29 @@
 #include <set>
 #include <unordered_set>
 
+#if defined(BROMAIDA_PLATFORM_ANDROID32) || defined(BROMAIDA_PLATFORM_ANDROID64)
+
+// idaclang thinks empty classes occupy 0 bytes of space therefore breaking the
+// implementation of std::map/std::set (caused by the empty class std::less)
+template <typename T>
+struct custom_less : std::less<T>
+{
+    bool pad;
+};
+
+namespace std
+{
+    // providing custom specializations for standard library templates is
+    // technically UB but clang allows it
+    template <typename Key, typename T, typename Alloc>
+    class map<Key, T, less<Key>, Alloc> : public map<Key, T, custom_less<Key>, Alloc> {};
+
+    template <typename Key, typename Alloc>
+    class set<Key, less<Key>, Alloc> : public set<Key, custom_less<Key>, Alloc> {};
+}
+
+#endif
+
 #endif
 
 #include "enums.hpp"


### PR DESCRIPTION
This should be enough to fix std::map and std::set being registered with incorrect size (caused by the empty class `std::less`).

The fix uses custom partial specializations of both of the containers which even though is technically UB, it's the best approach I could think of for the purposes of this plugin as it still falls back to the implementation provided by the standard headers and clang allows it without issues.